### PR TITLE
Add buzzers and show answer "award" status on game board

### DIFF
--- a/TriviaGame.Data/Services/Impl/GameSessionInfo.cs
+++ b/TriviaGame.Data/Services/Impl/GameSessionInfo.cs
@@ -32,6 +32,8 @@ namespace TriviaGame.Data.Services.Impl
         public int TotalAnswers { get; set; }
 
         public Player Host { get; set; }
+
+        public bool BuzzersEnabled { get; set; }
     }
 
     public class Player
@@ -39,12 +41,15 @@ namespace TriviaGame.Data.Services.Impl
         public string ConnectionId { get; set; }
 
         public Team Team { get; set; }
+
+        public int BuzzerPosition { get; set; }
     }
 
     public enum Team
     {
         Unknown = 0,
-        One = 1,
-        Two = 2
+        NoTeam = 1,
+        One = 2,
+        Two = 3
     }
 }

--- a/TriviaGame.Data/Services/Interfaces/IGameBoardHub.cs
+++ b/TriviaGame.Data/Services/Interfaces/IGameBoardHub.cs
@@ -17,5 +17,11 @@ namespace TriviaGame.Data.Services.Interfaces
         Task HostChanged(Player hostId);
 
         Task TriviaAnswersRevealed(params TriviaAnswer[] answers);
+
+        Task BuzzerStateChanged(bool newState);
+
+        Task ConfirmBuzzerPressReceived(string connectionId, int buzzerPosition);
+
+        Task ClearOldBuzzerPositions();
     }
 }

--- a/TriviaGame.Web/src/GameSessionInfo.ts
+++ b/TriviaGame.Web/src/GameSessionInfo.ts
@@ -1,5 +1,5 @@
-import {TriviaAnswer, TriviaBoard} from '@/models.g';
-import {Player, Team} from '@/Player';
+import {Team, TriviaAnswer, TriviaBoard} from '@/models.g';
+import {Player} from '@/Player';
 
 export class GameSessionInfo {
 
@@ -33,6 +33,8 @@ export class GameSessionInfo {
 
   public totalAnswers: number;
 
+  public buzzersEnabled: boolean;
+
   public host: Player | null;
   constructor() {
     this.gameId = null;
@@ -40,5 +42,6 @@ export class GameSessionInfo {
     this.triviaBoard = new TriviaBoard();
     this.totalAnswers = 0;
     this.host = null;
+    this.buzzersEnabled = false;
   }
 }

--- a/TriviaGame.Web/src/Player.ts
+++ b/TriviaGame.Web/src/Player.ts
@@ -1,15 +1,14 @@
+import {Team} from '@/models.g';
+
 export class Player {
 
   public connectionId: string;
   public team: Team;
+  public buzzerPosition: number | null;
+
   constructor(connectionId: string, team: Team) {
     this.connectionId = connectionId;
     this.team = team;
+    this.buzzerPosition = null;
   }
-}
-
-export enum Team {
-  Unknown = 0,
-  One = 1,
-  Two = 2,
 }

--- a/TriviaGame.Web/src/components/GameBoard.vue
+++ b/TriviaGame.Web/src/components/GameBoard.vue
@@ -55,7 +55,7 @@ export default class GameBoard extends Vue {
   }
 
   public awardPointsToNoTeam(answer: TriviaAnswer) {
-    this.awardPointsForAnswer(answer, Team.Unknown);
+    this.awardPointsForAnswer(answer, Team.NoTeam);
   }
 
   public awardPointsToTeamOne(answer: TriviaAnswer) {

--- a/TriviaGame.Web/src/components/GameBoardTable.vue
+++ b/TriviaGame.Web/src/components/GameBoardTable.vue
@@ -4,23 +4,23 @@
     <v-item v-for="(triviaAnswer, index) in answers" v-slot="{ active, toggle }">
       <tr>
         <template v-if="triviaAnswer">
-          <td :class="'thin-right-border ' + (isRight ? 'thick-left-border' : '')" style="width: 90%"
+          <td :class="'thin-right-border ' + (isRight ? 'thick-left-border' : '') + ' ' + getRowClass(triviaAnswer)" style="width: 90%"
               v-if="!active || !isHost">
-            {{ triviaAnswer.answer }}
+            <h3 :class="getRowTextClass(triviaAnswer)">{{ triviaAnswer.answer }}</h3>
           </td>
-          <td :class="'text-center ' + (isLeft && !isHost ? 'thick-right-border' : '')" style="width: 10%"
+          <td :class="'text-center ' + (isLeft && !isHost ? 'thick-right-border' : '') + ' ' + getRowClass(triviaAnswer)" style="width: 10%"
               v-if="!active || !isHost">
-            {{ triviaAnswer.points }}
+            <h3 :class="getRowTextClass(triviaAnswer)">{{ triviaAnswer.points }}</h3>
           </td>
           <td :class="(isRight ? 'thick-left-border' : '')" :colspan="(shouldColspan ? 2 : 0)" style="width: 100%" v-if="active && isHost">
             <v-row class="justify-space-around" no-gutters>
-              <v-col align="center" cols="4"><v-btn small @click="teamOne(triviaAnswer)" class="primary">Team One</v-btn></v-col>
-              <v-col align="center" cols="4"><v-btn small @click="noTeam(triviaAnswer)" class="warning">No Team</v-btn></v-col>
-              <v-col align="center" cols="4"><v-btn small @click="teamTwo(triviaAnswer)" class="secondary">Team Two</v-btn></v-col>
+              <v-col align="center" cols="4"><v-btn small @click="teamOne(triviaAnswer)" class="primary" color="teamOne">Team One</v-btn></v-col>
+              <v-col align="center" cols="4"><v-btn small @click="noTeam(triviaAnswer)" class="primary" color="noTeam">No Team</v-btn></v-col>
+              <v-col align="center" cols="4"><v-btn small @click="teamTwo(triviaAnswer)" class="primary" color="teamTwo">Team Two</v-btn></v-col>
             </v-row>
           </td>
           <td align="right" class="px-0 thick-left-border" v-if="isHost">
-            <v-btn @click="toggle" x-small style="height: 100%">
+            <v-btn @click="toggle" x-small style="height: 100%" class="primary">
               <v-icon>fas fa-arrow-{{ active ? 'right' : 'left' }}</v-icon>
             </v-btn>
           </td>
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 import {Component, Prop, Vue} from 'vue-property-decorator';
-import {TriviaAnswer} from '@/models.g';
+import {Team, TriviaAnswer} from '@/models.g';
 
 @Component({})
 export default class GameBoardTable extends Vue {
@@ -59,6 +59,28 @@ export default class GameBoardTable extends Vue {
 
   @Prop({type: Number, required: false})
   public indexOffset: number | undefined;
+
+  public getRowTextClass(answer: TriviaAnswer) {
+    switch (answer.wonBy) {
+      case Team.One:
+        return 'white--text';
+      case Team.Two:
+        return 'white--text';
+      case Team.NoTeam:
+        return 'white--text';
+    }
+  }
+
+  public getRowClass(answer: TriviaAnswer) {
+    switch (answer.wonBy) {
+      case Team.One:
+        return 'team-one-background';
+      case Team.Two:
+        return 'team-two-background';
+      case Team.NoTeam:
+        return 'no-team-background';
+    }
+  }
 
   public get shouldColspan(): boolean {
     return this.answers.filter((value) => !!value).length > 1;
@@ -94,7 +116,24 @@ export default class GameBoardTable extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+.gameboard-row-text {
+  color: white;
+  font-weight: bolder;
+}
+
+.team-one-background {
+  background-color: var(--v-teamOne-base);
+}
+
+.team-two-background {
+  background-color: var(--v-teamTwo-base);
+}
+
+.no-team-background {
+  background-color: var(--v-noTeam-base);
+}
+
 .thin-right-border {
   border-right: solid 1px;
 }

--- a/TriviaGame.Web/src/components/PlayerList.vue
+++ b/TriviaGame.Web/src/components/PlayerList.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <h1>Points: {{ teamPointsTotal }}</h1>
-    <v-btn @click="joinTeamButtonClicked" class="primary" v-if="!isInTeam">Join {{ teamName }}</v-btn>
+    <v-btn @click="joinTeamButtonClicked" class="primary mb-1" :color="color" v-if="!isInTeam">Join {{ teamName }}</v-btn>
     <v-expansion-panels>
       <v-expansion-panel>
-        <v-expansion-panel-header>
+        <v-expansion-panel-header :class="expansionHeaderClass + ' white--text'">
           <v-row class="ma-0 pa-0" no-gutters>
             <v-col align="center">{{ teamName }}</v-col>
             <v-col align="center" vertical><v-divider vertical/></v-col>
@@ -12,11 +12,16 @@
           </v-row>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          <v-simple-table>
+          <v-simple-table class="mt-2">
             <tr v-for="player in players">
               <td>
                 <v-icon v-if="player.connectionId === connectionId">fas fa-user</v-icon>
+              </td>
+              <td align="center" style="width: 100%">
                 {{ player.connectionId }}
+              </td>
+              <td>
+                <v-chip v-if="player.buzzerPosition && player.buzzerPosition > 0">{{ player.buzzerPosition }}</v-chip>
               </td>
             </tr>
           </v-simple-table>
@@ -47,6 +52,12 @@ export default class PlayerList extends Vue {
   @Prop({type: Number, required: true})
   public teamPointsTotal!: number;
 
+  @Prop({type: String, required: true})
+  public color!: string;
+
+  @Prop({type: String, required: true})
+  public expansionHeaderClass!: string;
+
   public joinTeamButtonClicked() {
     this.$emit('joinTeamClicked');
   }
@@ -54,5 +65,4 @@ export default class PlayerList extends Vue {
 </script>
 
 <style lang="scss" scoped>
-
 </style>

--- a/TriviaGame.Web/src/main.ts
+++ b/TriviaGame.Web/src/main.ts
@@ -11,6 +11,7 @@ import '@/site.scss';
 
 // SETUP: vuetify
 import Vuetify from 'vuetify';
+import colors from 'vuetify/lib/util/colors';
 Vue.use(Vuetify);
 const vuetify = new Vuetify({
   icons: {
@@ -26,7 +27,10 @@ const vuetify = new Vuetify({
         // primary: "#9ccc6f",
         // secondary: "#4d97bc",
         // accent: "#e98f07",
-        error: '#df323b', // This is the default error color with darken-1
+        error: '#df323b', // This is the default error color with darken-1,
+        teamOne: colors.purple.base,
+        teamTwo: colors.green.base,
+        noTeam: colors.orange.base,
       },
     },
   },

--- a/TriviaGame.Web/src/metadata.g.ts
+++ b/TriviaGame.Web/src/metadata.g.ts
@@ -10,10 +10,11 @@ export const Team = domain.enums.Team = {
   name: "Team",
   displayName: "Team",
   type: "enum",
-  ...getEnumMeta<"Unknown"|"One"|"Two">([
+  ...getEnumMeta<"Unknown"|"NoTeam"|"One"|"Two">([
     { value: 0, strValue: 'Unknown', displayName: 'Unknown' },
-    { value: 1, strValue: 'One', displayName: 'One' },
-    { value: 2, strValue: 'Two', displayName: 'Two' },
+    { value: 1, strValue: 'NoTeam', displayName: 'No Team' },
+    { value: 2, strValue: 'One', displayName: 'One' },
+    { value: 3, strValue: 'Two', displayName: 'Two' },
   ]),
 }
 export const TriviaBoard = domain.types.TriviaBoard = {

--- a/TriviaGame.Web/src/models.g.ts
+++ b/TriviaGame.Web/src/models.g.ts
@@ -3,8 +3,9 @@ import { Model, DataSource, convertToModel, mapToModel } from 'coalesce-vue/lib/
 
 export enum Team {
   Unknown = 0,
-  One = 1,
-  Two = 2,
+  NoTeam = 1,
+  One = 2,
+  Two = 3,
 }
 
 


### PR DESCRIPTION
- Adds coloring based on Team Color to the game board to indicate what team the answer was "awarded" to by the host
  - Setup Vuetify theme coloring for Team One, Team Two, and No Team (used when neither team guessed correctly)
- Add buzzers, and the ability for the host to lock out buzzers and clear them when necessary
- Add buzz in position to the player list for all players so everyone can see in what order the buzzers were pressed

Closes #4
Closes #15